### PR TITLE
Added Host field to Handle configuration form.

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -42,6 +42,13 @@ function islandora_handle_server_form($form, &$form_state) {
     '#description' => t('Handle prefix as specified from Handle.net'),
     '#default_value' => variable_get('islandora_handle_server_prefix', '1234567'),
   );
+  /** islandora_handle_host initial value is empty and will default resolver to ingestion host. */
+  $form['server_handle_host'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Hostname ex:http://example.com/'),
+    '#description' => t('URL that should be used'),
+    '#default_value' => variable_get('islandora_handle_host', ''),
+  );
   $form['server_handle_submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save configuration'),

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -42,7 +42,7 @@ function islandora_handle_server_form($form, &$form_state) {
     '#description' => t('Handle prefix as specified from Handle.net'),
     '#default_value' => variable_get('islandora_handle_server_prefix', '1234567'),
   );
-  /** islandora_handle_host initial value is empty and will default resolver to ingestion host. */
+  // islandora_handle_host initial value is empty and will default resolver to ingestion host. 
   $form['server_handle_host'] = array(
     '#type' => 'textfield',
     '#title' => t('Hostname ex:http://example.com/'),
@@ -86,7 +86,7 @@ function islandora_handle_server_form_submit($form, &$form_state) {
   variable_set('islandora_handle_server_admin_username', $form_state['values']['server_handle_admin_user']);
   variable_set('islandora_handle_server_admin_password', $form_state['values']['server_handle_admin_password']);
   variable_set('islandora_handle_server_prefix', $form_state['values']['server_handle_prefix']);
-
+  variable_set('islandora_handle_host', $form_state['values']['server_handle_host']);
   drupal_set_message(t('The settings have been saved!'));
 }
 

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -42,7 +42,8 @@ function islandora_handle_server_form($form, &$form_state) {
     '#description' => t('Handle prefix as specified from Handle.net'),
     '#default_value' => variable_get('islandora_handle_server_prefix', '1234567'),
   );
-  // islandora_handle_host initial value is empty and will default resolver to ingestion host. 
+  // islandora_handle_host initial value is empty and will default resolver to
+  // ingestion host.
   $form['server_handle_host'] = array(
     '#type' => 'textfield',
     '#title' => t('Hostname ex:http://example.com/'),

--- a/includes/handle.inc
+++ b/includes/handle.inc
@@ -19,17 +19,20 @@ function islandora_handle_construct_handle(AbstractObject $object) {
   $admin_password = variable_get('islandora_handle_server_admin_password', 'superSecretPassword');
   $handle_service_url = islandora_handle_construct_url($object, TRUE);
   $suffix = islandora_handle_construct_suffix($object);
-  // $hostvar will be populated if host resolver is different than ingestion service
+  // $hostvar will be populated if host resolver is different than ingestion
+  // service.
   $hostvar = variable_get('islandora_handle_host', '');
   if ($hostvar == '') {
-  // We do this with language such that we don't get language specific prefixes
-  // in the URL.
+    // We do this with language such that we don't get language specific
+    // prefixes in the URL.
     $target = url("islandora/object/$suffix", array(
       'language' => (object) array('language' => FALSE),
       'absolute' => TRUE,
     ));
   }
-  else { $target = $hostvar . "islandora/object/$suffix"; }
+  else {
+    $target = $hostvar . "islandora/object/$suffix";
+  }
   $query_target = drupal_http_build_query(array('target' => $target));
   $authorization_header = 'Basic ' . base64_encode($admin_user . ':' . $admin_password);
   $response = drupal_http_request($handle_service_url, array(

--- a/includes/handle.inc
+++ b/includes/handle.inc
@@ -19,12 +19,17 @@ function islandora_handle_construct_handle(AbstractObject $object) {
   $admin_password = variable_get('islandora_handle_server_admin_password', 'superSecretPassword');
   $handle_service_url = islandora_handle_construct_url($object, TRUE);
   $suffix = islandora_handle_construct_suffix($object);
+  // $hostvar will be populated if host resolver is different than ingestion service
+  $hostvar = variable_get('islandora_handle_host', '');
+  if ($hostvar == '') {
   // We do this with language such that we don't get language specific prefixes
   // in the URL.
-  $target = url("islandora/object/$suffix", array(
-    'language' => (object) array('language' => FALSE),
-    'absolute' => TRUE,
-  ));
+    $target = url("islandora/object/$suffix", array(
+      'language' => (object) array('language' => FALSE),
+      'absolute' => TRUE,
+    ));
+  }
+  else { $target = $hostvar . "islandora/object/$suffix"; }
   $query_target = drupal_http_build_query(array('target' => $target));
   $authorization_header = 'Basic ' . base64_encode($admin_user . ':' . $admin_password);
   $response = drupal_http_request($handle_service_url, array(


### PR DESCRIPTION
The use case for this proposed change is to provide the site administrator the ability to determine the Handle resolver host, which may different from the host performing the ingestion.  The current module configuration creates the resolver handle host by using the site URL.  Using the site URL as the host to resolve to is not always the desired effect.
