### PR TITLE
INT-1090 defined variable

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -34,13 +34,12 @@ function islandora_handle_append_handle_from_configuration(AbstractObject $objec
       $handle_exists = TRUE;
     }
     else {
-      $response->error;
       return array(
         'success' => FALSE,
         'messages' => array(
           array(
             'message' => t('Error constructing Handle for @obj! Error of: @error.'),
-            'message_sub' => array('@error' => $response, '@obj' => $object->id),
+            'message_sub' => array('@error' => $response->error, '@obj' => $object->id),
             'type' => 'watchdog',
             'severity' => WATCHDOG_ERROR,
           ),

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -34,6 +34,7 @@ function islandora_handle_append_handle_from_configuration(AbstractObject $objec
       $handle_exists = TRUE;
     }
     else {
+      $error = $response->error;
       return array(
         'success' => FALSE,
         'messages' => array(

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -34,13 +34,13 @@ function islandora_handle_append_handle_from_configuration(AbstractObject $objec
       $handle_exists = TRUE;
     }
     else {
-      $error = $response->error;
+      $response->error;
       return array(
         'success' => FALSE,
         'messages' => array(
           array(
             'message' => t('Error constructing Handle for @obj! Error of: @error.'),
-            'message_sub' => array('@error' => $error, '@obj' => $object->id),
+            'message_sub' => array('@error' => $response, '@obj' => $object->id),
             'type' => 'watchdog',
             'severity' => WATCHDOG_ERROR,
           ),


### PR DESCRIPTION
Jira Ticket: https://discoverygarden.atlassian.net/browse/INT-1092

What does this pull request do?
Prevents an error in drupal coming up after an object was ingested. The error told the user that a variable was undefined. This took place after the islandora_handle module was installed and and a handle was added with a content type selected. That error no longer is displayed. 

What has changed?
 The $error variable has been defined in derivative.inc
