### PR TITLE
Apply templates to attributes of mods:mods element.

### DIFF
--- a/transforms/handle_the_MODS.xsl
+++ b/transforms/handle_the_MODS.xsl
@@ -12,10 +12,10 @@
     <xsl:template match="/">
         <xsl:apply-templates/>
     </xsl:template>
-    
+
     <xsl:template match="mods:mods">
         <xsl:copy>
-            <xsl:apply-templates/>
+            <xsl:apply-templates select="node()|@*"/>
             <identifier type="hdl">
                 <xsl:value-of select="$handle_value"/>
             </identifier>


### PR DESCRIPTION
The 'version' and 'xsi:schemaLocation' attributes were removed from our MODS by this transform.
Before the transform the MODS was like this:
`<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.5" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">`
`...`
`</mods>`

But after the transform  the MODS was like this:
`<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3">`
`...`
`</mods>`

This bugfix makes sure that all the attributes of the mods:mods element are kept.