### PR TITLE
Honour function description in IslandoraHandleDebugHandler

### DIFF
--- a/includes/IslandoraHandleDebugHandler.class.inc
+++ b/includes/IslandoraHandleDebugHandler.class.inc
@@ -6,6 +6,23 @@
 class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
 
   /**
+   * Get the suffix from an existing handle or object.
+   *
+   * @param string|AbstractObject $handle
+   *   A Handle that we are updating in prefix/suffix form or an AbstractObject
+   *   that is being updated. In the AbstractObject case a Handle URL will be
+   *   constructed.
+   *
+   * @return string
+   *   The suffix of an existing handle.
+   */
+  private function getSuffix($handle) {
+    $full_handle = $this->getFullHandle($handle);
+    $prefix = variable_get('islandora_handle_server_prefix', '1234567');
+    return str_replace("$prefix/", '', $full_handle);
+  }
+
+  /**
    * Creates a Handle in the database for debugging.
    *
    * @param AbstractObject $object
@@ -37,10 +54,11 @@ class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
    *   The location of the Handle if it exists; FALSE otherwise.
    */
   public function readHandle($handle) {
+    $suffix = $this->getSuffix($handle);
     // Need to munge just the suffix out for debug case.
     return db_select('islandora_handle_debug_handles', 'd')
       ->fields('d', array('location'))
-      ->condition('suffix', $handle->id, '=')
+      ->condition('suffix', $suffix, '=')
       ->execute()
       ->fetchField();
   }
@@ -59,8 +77,7 @@ class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
    *   TRUE if successful; FALSE otherwise.
    */
   public function updateHandle($handle, $target) {
-    $prefix = variable_get('islandora_handle_server_prefix', '1234567');
-    $suffix = str_replace("$prefix/", '', $handle);
+    $suffix = $this->getSuffix($handle);
     db_merge('islandora_handle_debug_handles')
       ->fields(array(
         'location' => $target,
@@ -83,8 +100,9 @@ class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
    *   TRUE if successful; FALSE otherwise.
    */
   public function deleteHandle($handle) {
+    $suffix = $this->getSuffix($handle);
     db_delete('islandora_handle_debug_handles')
-      ->condition('suffix', $handle->id)
+      ->condition('suffix', $suffix)
       ->execute();
     return TRUE;
   }


### PR DESCRIPTION
The read, update and delete handle functions should be able to handle
an Islandora object or a string containing the handle according to the function descriptions.
But the IslandoraHandleDebugHandler class functions can only handle a
object.
This PR solves this inconsistency.