### PR TITLE
Use alias for target

### DIFF
--- a/includes/IslandoraHandleHandleHandler.class.inc
+++ b/includes/IslandoraHandleHandleHandler.class.inc
@@ -67,20 +67,19 @@ abstract class IslandoraHandleHandleHandler {
       // $hostvar will be populated if host resolver is different than ingestion
       // service.
       $hostvar = variable_get('islandora_handle_host', '');
+      // We call the function url with language such that we don't get language specific
+      // prefixes in the URL.
+      // Also, if alias = TRUE it means that the path is used as-is, no alias for the path is used.
+      $target_url = url("islandora/object/$suffix", array(
+        'language' => (object) array('language' => FALSE),
+        'absolute' => empty($hostvar),
+        'alias'    => !variable_get('islandora_handle_use_alias', FALSE),
+      ));
       if (empty($hostvar)) {
-        // We do this with language such that we don't get language specific
-        // prefixes in the URL.
-        $this->targetUrl = url("islandora/object/$suffix", array(
-          'language' => (object) array('language' => FALSE),
-          'absolute' => TRUE,
-        ));
+        $this->targetUrl = $target_url;
       }
       else {
-        $path = url("islandora/object/$suffix", array(
-          'language' => (object) array('language' => FALSE),
-          'absolute' => FALSE,
-        ));
-        $this->targetUrl = rtrim($hostvar, '/') . '/' . ltrim($path, '/');
+        $this->targetUrl = rtrim($hostvar, '/') . '/' . ltrim($target_url, '/');
       }
     }
     return $this->targetUrl;

--- a/includes/IslandoraHandleHandleHandler.class.inc
+++ b/includes/IslandoraHandleHandleHandler.class.inc
@@ -70,15 +70,18 @@ abstract class IslandoraHandleHandleHandler {
       if (empty($hostvar)) {
         // We do this with language such that we don't get language specific
         // prefixes in the URL.
-        return url("islandora/object/$suffix", array(
+        $this->targetUrl = url("islandora/object/$suffix", array(
           'language' => (object) array('language' => FALSE),
           'absolute' => TRUE,
         ));
       }
-      $this->targetUrl = format_string('!hostislandora/object/!suffix', array(
-        '!host' => $hostvar,
-        '!suffix' => $suffix,
-      ));
+      else {
+        $path = url("islandora/object/$suffix", array(
+          'language' => (object) array('language' => FALSE),
+          'absolute' => FALSE,
+        ));
+        $this->targetUrl = rtrim($hostvar, '/') . '/' . ltrim($path, '/');
+      }
     }
     return $this->targetUrl;
   }

--- a/includes/IslandoraHandleHandleHandler.class.inc
+++ b/includes/IslandoraHandleHandleHandler.class.inc
@@ -67,9 +67,10 @@ abstract class IslandoraHandleHandleHandler {
       // $hostvar will be populated if host resolver is different than ingestion
       // service.
       $hostvar = variable_get('islandora_handle_host', '');
-      // We call the function url with language such that we don't get language specific
-      // prefixes in the URL.
-      // Also, if alias = TRUE it means that the path is used as-is, no alias for the path is used.
+      // We call the function url with language such that we don't get language
+      // specific prefixes in the URL.
+      // Also, if alias = TRUE it means that the path is used as-is, no alias
+      // for the path is used.
       $target_url = url("islandora/object/$suffix", array(
         'language' => (object) array('language' => FALSE),
         'absolute' => empty($hostvar),

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -80,6 +80,12 @@ function islandora_handle_server_form(array $form, array &$form_state) {
     '#description' => t('URL that should be used when constructing a target URL. Leaving empty will use the default site name. <br />Example: http://example.com/'),
     '#default_value' => variable_get('islandora_handle_host', ''),
   );
+  $form['server_handle_use_alias'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use alias as target'),
+    '#description' => t('If unchecked when constructing the target URL, use islandora/object/PID as the target. If checked when constructing the target URL, use the URL alias if it exists.'),
+    '#default_value' => variable_get('islandora_handle_use_alias', FALSE),
+  );
   $form['server_handle_submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save configuration'),
@@ -118,6 +124,8 @@ function islandora_handle_server_form_submit(array $form, array &$form_state) {
   variable_set('islandora_handle_server_prefix', $form_state['values']['server_handle_prefix']);
 
   variable_set('islandora_handle_host', $form_state['values']['server_handle_host']);
+
+  variable_set('islandora_handle_use_alias', $form_state['values']['server_handle_use_alias']);
 
   // Only create the debug table if needed.
   if (!db_table_exists('islandora_handle_debug_handles') && $default_handler === 'islandora_handle_debug') {

--- a/islandora_handle.install
+++ b/islandora_handle.install
@@ -31,6 +31,7 @@ function islandora_handle_uninstall() {
     'islandora_handle_server_prefix',
     'islandora_handle_server_url',
     'islandora_handle_handler',
+    'islandora_handle_use_alias',
   );
   array_walk($variables, 'variable_del');
 


### PR DESCRIPTION
When generating the target url there are a couple of issues this PR fixes:
- the ```islandora_handle_host``` (if used) must end with an / (which is not obvious);
- the alias of the path is used only when ```islandora_handle_host``` is empty, but not when a ```islandora_handle_host``` is supplied (which is inconsistent);
- whether or not an alias is used, is not configurable;
- the ```$this->targetUrl``` is only set when ```islandora_handle_host``` is not empty;

