### PR TITLE
Debug with the full handle

### DIFF
--- a/includes/IslandoraHandleDebugHandler.class.inc
+++ b/includes/IslandoraHandleDebugHandler.class.inc
@@ -6,23 +6,6 @@
 class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
 
   /**
-   * Get the suffix from an existing handle or object.
-   *
-   * @param string|AbstractObject $handle
-   *   A Handle that we are updating in prefix/suffix form or an AbstractObject
-   *   that is being updated. In the AbstractObject case a Handle URL will be
-   *   constructed.
-   *
-   * @return string
-   *   The suffix of an existing handle.
-   */
-  private function getSuffix($handle) {
-    $full_handle = $this->getFullHandle($handle);
-    $prefix = variable_get('islandora_handle_server_prefix', '1234567');
-    return str_replace("$prefix/", '', $full_handle);
-  }
-
-  /**
    * Creates a Handle in the database for debugging.
    *
    * @param AbstractObject $object
@@ -32,11 +15,10 @@ class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
    *   TRUE on creation; FALSE otherwise.
    */
   public function createHandle(AbstractObject $object) {
-    $suffix = $this->constructSuffix($object);
     db_insert('islandora_handle_debug_handles')
       ->fields(array(
-        'suffix' => $suffix,
-        'location' => $this->constructTargetUrl($suffix),
+        'handle' => $this->getFullHandle($object),
+        'location' => $this->constructTargetUrl($object),
       ))
       ->execute();
     return TRUE;
@@ -54,11 +36,10 @@ class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
    *   The location of the Handle if it exists; FALSE otherwise.
    */
   public function readHandle($handle) {
-    $suffix = $this->getSuffix($handle);
-    // Need to munge just the suffix out for debug case.
+    $full_handle = $this->getFullHandle($handle);
     return db_select('islandora_handle_debug_handles', 'd')
       ->fields('d', array('location'))
-      ->condition('suffix', $suffix, '=')
+      ->condition('handle', $full_handle, '=')
       ->execute()
       ->fetchField();
   }
@@ -77,13 +58,13 @@ class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
    *   TRUE if successful; FALSE otherwise.
    */
   public function updateHandle($handle, $target) {
-    $suffix = $this->getSuffix($handle);
+    $full_handle = $this->getFullHandle($handle);
     db_merge('islandora_handle_debug_handles')
       ->fields(array(
         'location' => $target,
-        'suffix' => $suffix,
+        'handle' => $full_handle,
       ))
-      ->condition('suffix', $suffix)
+      ->condition('handle', $full_handle)
       ->execute();
     return TRUE;
   }
@@ -100,9 +81,9 @@ class IslandoraHandleDebugHandler extends IslandoraHandleHandleHandler {
    *   TRUE if successful; FALSE otherwise.
    */
   public function deleteHandle($handle) {
-    $suffix = $this->getSuffix($handle);
+    $full_handle = $this->getFullHandle($handle);
     db_delete('islandora_handle_debug_handles')
-      ->condition('suffix', $suffix)
+      ->condition('handle', $full_handle)
       ->execute();
     return TRUE;
   }

--- a/includes/IslandoraHandleHandleHandler.class.inc
+++ b/includes/IslandoraHandleHandleHandler.class.inc
@@ -52,17 +52,18 @@ abstract class IslandoraHandleHandleHandler {
   /**
    * Helper to construct a target URL.
    *
-   * Constructed from islandora/object, appended with the given $object->id and
+   * Constructed from islandora/object, appended with the $pid of an object and
    * prepended with either the local server's URL or the custom configured
    * variable islandora_handle_host.
    *
-   * @param AbstractObject $object
-   *   The object that is the target of the URL.
+   * @param string|AbstractObject $object
+   *   The pid of the object or object itself that is the target of the URL.
    *
    * @return string
    *   The constructed target URL.
    */
-  public function constructTargetUrl(AbstractObject $object) {
+  public function constructTargetUrl($object) {
+    $pid = $handle instanceof AbstractObject ? $object->id : $object;
     if (!$this->targetUrl) {
       // $hostvar will be populated if host resolver is different than ingestion
       // service.
@@ -71,7 +72,7 @@ abstract class IslandoraHandleHandleHandler {
       // specific prefixes in the URL.
       // Also, if alias = TRUE it means that the path is used as-is, no alias
       // for the path is used.
-      $target_url = url("islandora/object/" . $object->id, array(
+      $target_url = url("islandora/object/$pid", array(
         'language' => (object) array('language' => FALSE),
         'absolute' => empty($hostvar),
         'alias'    => !variable_get('islandora_handle_use_alias', FALSE),

--- a/includes/IslandoraHandleHandleHandler.class.inc
+++ b/includes/IslandoraHandleHandleHandler.class.inc
@@ -22,7 +22,7 @@ abstract class IslandoraHandleHandleHandler {
    */
   public function __construct(AbstractObject $object = NULL, $prefix = NULL) {
     if ($object instanceof AbstractObject) {
-      $this->targetUrl = $this->constructTargetUrl($object->id);
+      $this->targetUrl = $this->constructTargetUrl($object);
       $this->pid = $object->id;
     }
     if (is_null($prefix)) {
@@ -52,17 +52,17 @@ abstract class IslandoraHandleHandleHandler {
   /**
    * Helper to construct a target URL.
    *
-   * Constructed from islandora/object, appended with the given $suffix and
+   * Constructed from islandora/object, appended with the given $object->id and
    * prepended with either the local server's URL or the custom configured
    * variable islandora_handle_host.
    *
-   * @param string $suffix
-   *   Suffix to append to the URL.
+   * @param AbstractObject $object
+   *   The object that is the target of the URL.
    *
    * @return string
    *   The constructed target URL.
    */
-  public function constructTargetUrl($suffix) {
+  public function constructTargetUrl(AbstractObject $object) {
     if (!$this->targetUrl) {
       // $hostvar will be populated if host resolver is different than ingestion
       // service.
@@ -70,14 +70,14 @@ abstract class IslandoraHandleHandleHandler {
       if (empty($hostvar)) {
         // We do this with language such that we don't get language specific
         // prefixes in the URL.
-        return url("islandora/object/$suffix", array(
+        return url("islandora/object/" . $object->id, array(
           'language' => (object) array('language' => FALSE),
           'absolute' => TRUE,
         ));
       }
       $this->targetUrl = format_string('!hostislandora/object/!suffix', array(
         '!host' => $hostvar,
-        '!suffix' => $suffix,
+        '!suffix' => $object->id,
       ));
     }
     return $this->targetUrl;

--- a/includes/IslandoraHandleRestHandler.class.inc
+++ b/includes/IslandoraHandleRestHandler.class.inc
@@ -43,7 +43,7 @@ class IslandoraHandleRestHandler extends IslandoraHandleHandleHandler {
         array(
           'index' => 1,
           'type' => 'URL',
-          'data' => $this->constructTargetUrl($this->constructSuffix($object)),
+          'data' => $this->constructTargetUrl($object),
         ),
       )),
       'method' => 'PUT',

--- a/includes/IslandoraHandleServiceHandler.class.inc
+++ b/includes/IslandoraHandleServiceHandler.class.inc
@@ -15,7 +15,6 @@ class IslandoraHandleServiceHandler extends IslandoraHandleHandleHandler {
    *   TRUE on creation; FALSE otherwise.
    */
   public function createHandle(AbstractObject $object) {
-    $suffix = $this->constructSuffix($object);
     $full_handle = $this->getFullHandle($object);
 
     $response = drupal_http_request($this->getServiceUrl($full_handle), array(
@@ -23,7 +22,7 @@ class IslandoraHandleServiceHandler extends IslandoraHandleHandleHandler {
         'Authorization' => $this->authorizationHeader,
       ),
       'data' => drupal_http_build_query(array(
-        'target' => $this->constructTargetUrl($suffix),
+        'target' => $this->constructTargetUrl($object),
       )),
       'method' => 'POST',
     ));

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -124,8 +124,8 @@ function islandora_handle_server_form_submit(array $form, array &$form_state) {
     $table = array(
       'description' => 'Stores handles used during debug mode.',
       'fields' => array(
-        'suffix' => array(
-          'description' => 'The suffix of the handle.',
+        'handle' => array(
+          'description' => 'The handle.',
           'type' => 'varchar',
           'length' => 255,
           'not null' => TRUE,
@@ -136,7 +136,7 @@ function islandora_handle_server_form_submit(array $form, array &$form_state) {
           'length' => 255,
         ),
       ),
-      'primary key' => array('suffix'),
+      'primary key' => array('handle'),
     );
     db_create_table('islandora_handle_debug_handles', $table);
     db_table_exists('islandora_handle_debug_handles') ? drupal_set_message(t('Successfully created a handle debug table in the database.')) : drupal_set_message(t('An error occurred while attempting to create the handle debug table in the database.'), 'error');

--- a/includes/update_handles.batch.inc
+++ b/includes/update_handles.batch.inc
@@ -87,7 +87,7 @@ function islandora_handle_update_handles_batch_operation(array $params, &$contex
       $handler_class = islandora_handle_retrieve_selected_handler();
       $handler = new $handler_class($object);
       $handle = $handler->getFullHandle($object);
-      $target = $handler->constructTargetUrl($handler->constructSuffix($object));
+      $target = $handler->constructTargetUrl($object);
       if ($handler->updateHandle($object, $target)) {
         // Re-run derivative generation for configured DSID sources.
         $configs = islandora_handle_retrieve_configurations_by_cmodels($object->models);

--- a/islandora_handle.install
+++ b/islandora_handle.install
@@ -98,7 +98,7 @@ function islandora_handle_update_7002() {
     $keys_new = array(
       'primary key' => array('handle'),
     );
-    db_change_field('islandora_handle_debug_handles', 'suffix', 'handle', $spec);
+    db_change_field('islandora_handle_debug_handles', 'suffix', 'handle', $spec, $keys_new);
 
     // And last update the handle to be prefix + suffix.
     $prefix = variable_get('islandora_handle_server_prefix', '1234567') . '/';

--- a/islandora_handle.install
+++ b/islandora_handle.install
@@ -102,7 +102,7 @@ function islandora_handle_update_7002() {
     // And last update the handle to be prefix + suffix
     $prefix = variable_get('islandora_handle_server_prefix', '1234567') . '/';
     db_update('islandora_handle_debug_handles')
-      ->expression('handle', ':prefix + handle', array(':prefix' => $prefix))
+      ->expression('handle', 'concat(:prefix, handle)', array(':prefix' => $prefix))
       ->execute();
   }
 }

--- a/islandora_handle.install
+++ b/islandora_handle.install
@@ -78,3 +78,31 @@ function islandora_handle_update_7001(&$sandbox) {
     ->condition('datastream', 'DC')
     ->execute();
 }
+
+/**
+ * Update the debug table if needed.
+ */
+function islandora_handle_update_7002() {
+  if (db_table_exists('islandora_handle_debug_handles') && !db_field_exists('islandora_handle_debug_handles', 'handle')) {
+    // First drop the primary key
+    db_drop_primary_key('islandora_handle_debug_handles');
+
+    // Then change the field suffix to the field handle
+    $spec = array(
+      'description' => 'The handle.',
+      'type' => 'varchar',
+      'length' => 255,
+      'not null' => TRUE,
+    );
+    $keys_new = array(
+      'primary key' => array('handle'),
+    );
+    db_change_field('islandora_handle_debug_handles', 'suffix', 'handle', $spec);
+
+    // And last update the handle to be prefix + suffix
+    $prefix = variable_get('islandora_handle_server_prefix', '1234567') . '/';
+    db_update('islandora_handle_debug_handles')
+      ->expression('handle', ':prefix + handle', array(':prefix' => $prefix))
+      ->execute();
+  }
+}

--- a/islandora_handle.install
+++ b/islandora_handle.install
@@ -84,10 +84,10 @@ function islandora_handle_update_7001(&$sandbox) {
  */
 function islandora_handle_update_7002() {
   if (db_table_exists('islandora_handle_debug_handles') && !db_field_exists('islandora_handle_debug_handles', 'handle')) {
-    // First drop the primary key
+    // First drop the primary key.
     db_drop_primary_key('islandora_handle_debug_handles');
 
-    // Then change the field suffix to the field handle
+    // Then change the field suffix to the field handle.
     $spec = array(
       'description' => 'The handle.',
       'type' => 'varchar',
@@ -99,7 +99,7 @@ function islandora_handle_update_7002() {
     );
     db_change_field('islandora_handle_debug_handles', 'suffix', 'handle', $spec);
 
-    // And last update the handle to be prefix + suffix
+    // And last update the handle to be prefix + suffix.
     $prefix = variable_get('islandora_handle_server_prefix', '1234567') . '/';
     db_update('islandora_handle_debug_handles')
       ->expression('handle', 'concat(:prefix, handle)', array(':prefix' => $prefix))


### PR DESCRIPTION
When the debugging mode is used, only the suffix of the handle is stored in a local database. This is fine most of the time, but has the following issues:
- when using multiple prefixes for the handle (this is not common, but can happen when migrating two different systems that use different handle prefixes to islandora), the handles are not distinguishable and can cause problems;
- the debugging is different from the "normal" situation where the full handle is stored, which can make debugging problematic;
- the code in IslandoraHandleDebugHandler is not as straightforward as could be.

As a positive side effect the constructTargetUrl function can now take the Islandora object instead of the suffix of the handle. This will give greater flexibility in the future when constructing the target url, for example when the suffix is not actually part of the target url.