### PR TITLE
Only update metadata if handle does not exist

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -47,31 +47,33 @@ function islandora_handle_append_handle_from_configuration(AbstractObject $objec
         ),
       );
     }
-  }
-  $metadata_updated = FALSE;
-  foreach (islandora_handle_retrieve_configurations_by_cmodels($object->models) as $assoc) {
-    if ($hook['destination_dsid'] == $assoc->datastream && isset($object[$assoc->datastream])) {
-      $add_outcome = $handler->appendHandleToMetadata($object, $assoc->datastream, $assoc->xsl_location);
-      // XXX: When there's nothing to be done in the appending of metadata (when
-      // the datastream already contains the handle value) don't report any
-      // derivative logging as nothing actually happened.
-      if (isset($add_outcome['success'])) {
-        $metadata_updated = TRUE;
-        if (!$add_outcome['success']) {
-          $success = FALSE;
+
+    $metadata_updated = FALSE;
+    foreach (islandora_handle_retrieve_configurations_by_cmodels($object->models) as $assoc) {
+      if ($hook['destination_dsid'] == $assoc->datastream && isset($object[$assoc->datastream])) {
+        $add_outcome = $handler->appendHandleToMetadata($object, $assoc->datastream, $assoc->xsl_location);
+        // XXX: When there's nothing to be done in the appending of metadata
+        // (when the datastream already contains the handle value) don't report
+        // any derivative logging as nothing actually happened.
+        if (isset($add_outcome['success'])) {
+          $metadata_updated = TRUE;
+          if (!$add_outcome['success']) {
+            $success = FALSE;
+          }
+          $messages[] = $add_outcome['message'];
         }
-        $messages[] = $add_outcome['message'];
+        break;
       }
-      break;
     }
-  }
-  // In the event nothing gets updated is no messages/success result to pass on
-  // to the derivative logging.
-  if ($metadata_updated) {
-    return array(
-      'success' => $success,
-      'messages' => $messages,
-    );
+
+    // In the event nothing gets updated is no messages/success result to pass
+    // on to the derivative logging.
+    if ($metadata_updated) {
+      return array(
+        'success' => $success,
+        'messages' => $messages,
+      );
+    }
   }
   return array();
 }


### PR DESCRIPTION
This is a PR for issue #36 

In some cases when adding the handle to the MODS (and/or the DC) datastream during the derivative generation of an ingest, multiple (sometimes thousands) of MODS datastream versions are generated, all containing the handle and all are exactly the same.
This PR fixes this.