### PR TITLE
Error messages on read handle

### DIFF
--- a/includes/IslandoraHandleRestHandler.class.inc
+++ b/includes/IslandoraHandleRestHandler.class.inc
@@ -112,7 +112,7 @@ class IslandoraHandleRestHandler extends IslandoraHandleHandleHandler {
         '@type' => $handle_response_code ? t('Handle') : t('HTTP'),
         '@code' => $handle_response_code ? $handle_response_code['code'] : $response->code,
         '@error' => $handle_response_code ? $handle_response_code['message'] : $response->error,
-      ), WATCHDOG_ERROR);
+      ), WATCHDOG_DEBUG);
       return FALSE;
     }
 

--- a/includes/IslandoraHandleServiceHandler.class.inc
+++ b/includes/IslandoraHandleServiceHandler.class.inc
@@ -62,7 +62,7 @@ class IslandoraHandleServiceHandler extends IslandoraHandleHandleHandler {
       watchdog('islandora_handle', 'Unable to retrieve Handle location for @handle. Error: @error.', array(
         '@handle' => $full_handle,
         '@error' => $response->error,
-      ), WATCHDOG_ERROR);
+      ), WATCHDOG_DEBUG);
       return FALSE;
     }
 


### PR DESCRIPTION
This PR solves issue #40 

A lot of error messages come in the error logs when ingesting new objects:
"Unable to retrieve Handle location for handle. Handle error 100 with message: Handle not found."
When the handle is generated (thru the derivative process), the first thing that is done, is to check if the handle already exists (which makes sense). This is done by calling the readHandle method, which logs an error message when no handle was found.
This PR downgrades those messages to debug level.
