### PR TITLE
Add option to use https handle url

### DIFF
--- a/includes/IslandoraHandleHandleHandler.class.inc
+++ b/includes/IslandoraHandleHandleHandler.class.inc
@@ -115,7 +115,8 @@ abstract class IslandoraHandleHandleHandler {
    *   The Handle.net URL to be used in the metadata.
    */
   public function getHandleMetadataValue(AbstractObject $object) {
-    return format_string('http://hdl.handle.net/!handle', array(
+    return format_string('!protocol://hdl.handle.net/!handle', array(
+      '!protocol' => (variable_get('islandora_handle_use_https', FALSE) ? 'https' : 'http'),
       '!handle' => $this->getFullHandle($object),
     ));
   }

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -93,6 +93,12 @@ function islandora_handle_server_form(array $form, array &$form_state) {
     '#description' => t('If unchecked when constructing the target URL, use islandora/object/PID as the target. If checked when constructing the target URL, use the URL alias if it exists.'),
     '#default_value' => variable_get('islandora_handle_use_alias', FALSE),
   );
+  $form['server_handle_use_https'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use https for the hdl.handle.net URL'),
+    '#description' => t('If unchecked use http://hdl.handle.net. If checked use https://hdl.handle.net.'),
+    '#default_value' => variable_get('islandora_handle_use_https', FALSE),
+  );
   $form['server_handle_submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save configuration'),
@@ -135,6 +141,8 @@ function islandora_handle_server_form_submit(array $form, array &$form_state) {
   variable_set('islandora_handle_host', $form_state['values']['server_handle_host']);
 
   variable_set('islandora_handle_use_alias', $form_state['values']['server_handle_use_alias']);
+
+  variable_set('islandora_handle_use_https', $form_state['values']['server_handle_use_https']);
 
   // Only create the debug table if needed.
   if (!db_table_exists('islandora_handle_debug_handles') && $default_handler === 'islandora_handle_debug') {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -144,7 +144,9 @@ function islandora_handle_add_to_dc_datastream(AbstractObject $object, $force = 
     $handle_node = $dom->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', $handle_url);
 
     // First check if one exists such that we can replace it.
-    $identifier_results = $dom_xpath->query('/oai_dc:dc/dc:identifier[starts-with(text(), "http://hdl.handle.net")]');
+    $protocol = variable_get('islandora_handle_use_https', FALSE) ? 'https' : 'http';
+    $query = "/oai_dc:dc/dc:identifier[starts-with(text(), \"{$protocol}://hdl.handle.net\")]";
+    $identifier_results = $dom_xpath->query($query);
     foreach ($identifier_results as $node) {
       // This could trigger many times so let's be sure that the current Handle
       // value doesn't already exist to not create multiple versions.

--- a/islandora_handle.install
+++ b/islandora_handle.install
@@ -32,6 +32,7 @@ function islandora_handle_uninstall() {
     'islandora_handle_server_url',
     'islandora_handle_handler',
     'islandora_handle_use_alias',
+    'islandora_handle_use_https',
   );
   array_walk($variables, 'variable_del');
 


### PR DESCRIPTION
The handle url is stored in a metadata datastream (if so configured) when generating a handle, but the http version of the handle url is always used. Because this handle url might be visible in the metadata display and some web browsers frown on http URLs, this PR adds an option to use https handle URLs. The default is http, so nothing changes for current users, unless the option is enabled.